### PR TITLE
vulkan : DescriptorSets

### DIFF
--- a/include/vk/descriptors/descriptorPool.h
+++ b/include/vk/descriptors/descriptorPool.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <vulkan/vulkan.h>
-#include <array>
+#include <unordered_map>
 #include <vector>
 
 class DescriptorPool
@@ -13,7 +13,7 @@ class DescriptorPool
 public:
     DescriptorPool(
             VkDevice device,
-            const std::array<VkDescriptorPoolSize, VK_DESCRIPTOR_TYPE_RANGE_SIZE> &pool_sizes,
+            const std::unordered_map<VkDescriptorType, uint32_t> &pool_sizes,
             uint32_t max_set_count);
     DescriptorPool(const DescriptorPool &other_pool) = delete;
     DescriptorPool(DescriptorPool &&other_pool);

--- a/include/vk/descriptors/descriptorSetLayout.h
+++ b/include/vk/descriptors/descriptorSetLayout.h
@@ -3,17 +3,18 @@
 #include "descriptorSetInfo.h"
 #include <vulkan/vulkan.h>
 #include <vector>
-#include <array>
+#include <unordered_map>
 
 class DescriptorSetLayout
 {
     VkDescriptorSetLayout layout;
     VkDevice device;
     std::vector<VkDescriptorSetLayoutBinding> bindings;
-    std::array<VkDescriptorPoolSize, VK_DESCRIPTOR_TYPE_RANGE_SIZE> poolSizes;
+    std::unordered_map<VkDescriptorType, uint32_t> poolSizes;
     std::vector<DescriptorPool> pools;
 
     void clearPoolSizes();
+    void increaseDescriptorsCount(VkDescriptorType desc_type, int desc_count);
 
     std::vector<VkDescriptorSet> descriptorSets;
     DescriptorSetInfo descriptorSetInfo;

--- a/src/vk/descriptors/descriptorPool.cpp
+++ b/src/vk/descriptors/descriptorPool.cpp
@@ -6,20 +6,18 @@ uint32_t DescriptorPool::DEFAULT_SET_COUNT = 10;
 
 DescriptorPool::DescriptorPool(
         VkDevice device,
-        const std::array<VkDescriptorPoolSize, VK_DESCRIPTOR_TYPE_RANGE_SIZE> &pool_sizes,
+        const std::unordered_map<VkDescriptorType, uint32_t> &pool_sizes,
         uint32_t max_set_count
 ):
     maxSetCount(max_set_count), device(device), setCount(0)
 {
     std::vector<VkDescriptorPoolSize> nonzeroPoolSizes;
-    for (auto poolSize : pool_sizes)
+    for (auto [descType, descCount] : pool_sizes)
     {
-        if (poolSize.descriptorCount > 0)
-        {
-            auto actualPoolSize = poolSize;
-            actualPoolSize.descriptorCount *= max_set_count;
-            nonzeroPoolSizes.push_back(actualPoolSize);
-        }
+        VkDescriptorPoolSize actualPoolSize{};
+        actualPoolSize.type = descType;
+        actualPoolSize.descriptorCount = descCount*max_set_count;
+        nonzeroPoolSizes.push_back(actualPoolSize);
     }
 
     VkDescriptorPoolCreateInfo poolInfo{};

--- a/src/vk/descriptors/descriptorSetLayout.cpp
+++ b/src/vk/descriptors/descriptorSetLayout.cpp
@@ -4,20 +4,13 @@
 
 void DescriptorSetLayout::clearPoolSizes()
 {
-    for (int i = 0; i < poolSizes.size(); ++i)
-    {
-        poolSizes[i].descriptorCount = 0;
-    }
+    poolSizes.clear();
 }
 
 DescriptorSetLayout::DescriptorSetLayout():
         layout(VK_NULL_HANDLE), device(VK_NULL_HANDLE), setInd(0)
 {
     clearPoolSizes();
-    for (uint32_t i = VK_DESCRIPTOR_TYPE_BEGIN_RANGE; i <= VK_DESCRIPTOR_TYPE_END_RANGE; ++i)
-    {
-        poolSizes[i].type = static_cast<VkDescriptorType>(i);
-    }
 }
 
 
@@ -38,6 +31,15 @@ const VkDescriptorSetLayout &DescriptorSetLayout::createLayout(VkDevice device)
     return layout;
 }
 
+void DescriptorSetLayout::increaseDescriptorsCount(VkDescriptorType desc_type, int desc_count)
+{
+    if (poolSizes.find(desc_type) != poolSizes.end()) {
+        poolSizes[desc_type] += desc_count;
+    } else {
+        poolSizes[desc_type] = desc_count;
+    }
+}
+
 void DescriptorSetLayout::addUniformBuffer(uint32_t buf_size, VkShaderStageFlags stage_flags)
 {
     VkDescriptorSetLayoutBinding uboLayoutBinding{};
@@ -48,7 +50,7 @@ void DescriptorSetLayout::addUniformBuffer(uint32_t buf_size, VkShaderStageFlags
     uboLayoutBinding.pImmutableSamplers = nullptr; // Optional
 
     bindings.push_back(uboLayoutBinding);
-    poolSizes[VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER].descriptorCount += buf_size;
+    increaseDescriptorsCount(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, buf_size);
 }
 
 void DescriptorSetLayout::addCombinedImageSampler(VkShaderStageFlags stage_flags)
@@ -61,7 +63,7 @@ void DescriptorSetLayout::addCombinedImageSampler(VkShaderStageFlags stage_flags
     samplerLayoutBinding.stageFlags = stage_flags;
 
     bindings.push_back(samplerLayoutBinding);
-    poolSizes[VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER].descriptorCount += 1;
+    increaseDescriptorsCount(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1);
 }
 
 void DescriptorSetLayout::freePool()


### PR DESCRIPTION
Problem:
VK_DESCRIPTOR_TYPE_RANGE_SIZE and begin/end values in VkDescriptorType enum
are not supported in all versions of Vulkan SDK.

Solution:
std::array poolSizes is replaced by std::unordered_map.