### PR TITLE
WIN32 BUILD : fix of compilation via minGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,10 @@ set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 add_subdirectory(external/glfw)
 
 # compiling assimp
+if (MINGW)
+	add_compile_definitions(_SSIZE_T_DEFINED)
+endif()
+
 set(ASSIMP_BUILD_ASSIMP_TOOLS OFF CACHE BOOL "" FORCE)
 set(ASSIMP_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(ASSIMP_BUILD_ALL_EXPORTERS_BY_DEFAULT OFF CACHE BOOL "" FORCE)


### PR DESCRIPTION
Assimp zip compilation was failing with minGW cause of re typedef of ssize_t.