### PR TITLE
Logging: basic config features + timestamps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,9 @@ add_executable(${EXE_NAME}
 		include/vk/cmdSync.h
 		src/vk/cmdSync.cpp
 		include/app/config/JSON.h
-		include/app/log.hpp)
+		include/app/log.hpp
+		src/app/log.cpp
+)
 
 target_include_directories(${EXE_NAME}
 		PUBLIC include
@@ -186,6 +188,7 @@ add_executable(${TEST_EXE_NAME}
 		test/test_config.cpp
 		test/test_logger.cpp
 		test/test_main.cpp
+		src/app/log.cpp
 )
 # TODO: prorer setup
 target_include_directories(${TEST_EXE_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,7 @@ add_executable(${TEST_EXE_NAME}
 		test/test_logger.cpp
 		test/test_main.cpp
 		src/app/log.cpp
+		src/app/clock.cpp
 )
 # TODO: prorer setup
 target_include_directories(${TEST_EXE_NAME}

--- a/include/app/clock.h
+++ b/include/app/clock.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <chrono>
+#include <string>
 
 class Clock
 {
@@ -11,4 +12,37 @@ public:
     double getTime() const;
 
     static double seconds(long long microseconds);
+};
+
+class Time {
+public:
+    Time(const std::chrono::milliseconds &dur);
+    Time(int hour=0, int min=0, int s=0, int ms=0):
+        _hour(hour), _min(min), _s(s), _ms(ms) {}
+
+    int hours()         const  { return _hour; }
+    int minutes()       const  { return _min;  }
+    int seconds()       const  { return _s;    }
+    int milliseconds()  const  { return _ms;   }
+
+    void addHours(int hours);
+
+    std::string toStr() const;
+    friend std::ostream &operator<<(std::ostream &stream, const Time &t);
+private:
+    int _hour;
+    int _min;
+    int _s;
+    int _ms;
+};
+
+
+class SystemClock {
+public:
+    static Time getTime();
+
+private:
+    static int _zone_ofs;
+
+    static int getZoneOffset();
 };

--- a/include/app/config/JSON.h
+++ b/include/app/config/JSON.h
@@ -61,7 +61,7 @@ using JSON = nlohmann::basic_json<
 
 // @TODO: use map instead of linear search
 #define JSON_ENUM_MAPPING(type, ...)                                            \
-    void to_json(JSON &json, const type &value) {                               \
+    inline void to_json(JSON &json, const type &value) {                               \
         static const std::pair<type, std::string> mappings[] = {__VA_ARGS__};   \
         auto mapping = std::find_if(                                            \
             std::begin(mappings),                                               \
@@ -75,7 +75,7 @@ using JSON = nlohmann::basic_json<
         }                                                                       \
     }                                                                           \
                                                                                 \
-    void from_json(const JSON &json, type &value) {                             \
+    inline void from_json(const JSON &json, type &value) {                             \
         static const std::pair<type, std::string> mappings[] = {__VA_ARGS__};   \
         auto mapping = std::find_if(                                            \
             std::begin(mappings),                                               \

--- a/include/app/log.hpp
+++ b/include/app/log.hpp
@@ -3,7 +3,8 @@
 #include <iostream>
 #include <type_traits>
 #include <string>
-#include <array>
+#include <sstream>
+#include <app/clock.h>
 #include "app/config/JSON.h"
 
 class Log {
@@ -85,18 +86,17 @@ private:
 template <typename ... Args>
 void Log::message(Level level, const Args &... args) {
     // TODO: output to log file
-    // TODO: log timestamp
     // TODO: choose message format
     // TODO: add filtering by level
+    std::stringstream ss;
+    ss << "[" << SystemClock::getTime() << "] " << level << ' ';
+    (print<Args>(ss, args), ...);
+    ss << std::endl;
     if (_config.write_to_console) {
-        std::cerr << level << ' ';
-        (print<Args>(std::cerr, args), ...);
-        std::cerr << std::endl;
-        if (log_out_fs.is_open()) {
-            log_out_fs << level << ' ';
-            (print<Args>(log_out_fs, args), ...);
-            log_out_fs << std::endl;
-        }
+        std::cerr << ss.str();
+    }
+    if (log_out_fs.is_open()) {
+        log_out_fs << ss.str();
     }
 }
 

--- a/include/app/log.hpp
+++ b/include/app/log.hpp
@@ -22,7 +22,7 @@ public:
     struct Config {
         std::string   log_filename       =  "default_log.log";
         bool          write_to_console   =  true;
-        int           minimal_level      =  0;
+        Level         minimal_level      =  Level::DEBUG;
     private:
         JSON_MAPPINGS(
             {log_filename, "filename"},
@@ -71,6 +71,14 @@ private:
     template <typename T>
     static void print(std::ostream &stream, const T &object);
 };
+
+JSON_ENUM_MAPPING(Log::Level,
+    { Log::Level::DEBUG,    "DEBUG"    },
+    { Log::Level::INFO,     "INFO"     },
+    { Log::Level::WARNING,  "WARNING"  },
+    { Log::Level::ERROR,    "ERROR"    },
+    { Log::Level::CRITICAL, "CRITICAL" }
+)
 
 // TODO: move to common include file maybe
 #ifndef __FILENAME__

--- a/include/app/log.hpp
+++ b/include/app/log.hpp
@@ -32,7 +32,6 @@ public:
     };
 
     static void initFromConfig(const Log::Config &init_config);
-    static void initFromConfig(const std::string &filename);
 
     friend std::ostream &operator<<(std::ostream &stream, Log::Level level);
 
@@ -57,6 +56,7 @@ public:
 private:
     static Config _config;
     static std::ofstream log_out_fs;
+    static std::stringstream ss;
 
     static void init();
 
@@ -71,6 +71,11 @@ private:
     template <typename T>
     static void print(std::ostream &stream, const T &object);
 };
+
+bool operator<=(Log::Level l1, Log::Level l2);
+bool operator>=(Log::Level l1, Log::Level l2);
+bool operator<(Log::Level l1, Log::Level l2);
+bool operator>(Log::Level l1, Log::Level l2);
 
 JSON_ENUM_MAPPING(Log::Level,
     { Log::Level::DEBUG,    "DEBUG"    },
@@ -93,10 +98,11 @@ JSON_ENUM_MAPPING(Log::Level,
 
 template <typename ... Args>
 void Log::message(Level level, const Args &... args) {
-    // TODO: output to log file
     // TODO: choose message format
-    // TODO: add filtering by level
-    std::stringstream ss;
+    if (level < _config.minimal_level) {
+        return;
+    }
+    ss.str("");
     ss << "[" << SystemClock::getTime() << "] " << level << ' ';
     (print<Args>(ss, args), ...);
     ss << std::endl;
@@ -110,37 +116,27 @@ void Log::message(Level level, const Args &... args) {
 
 template <typename ... Args>
 void Log::debug(const Args &... args) {
-    if (static_cast<int>(_config.minimal_level) <= static_cast<int>(Level::DEBUG)) {
-        message(Level::DEBUG, args...);
-    }
+    message(Level::DEBUG, args...);
 }
 
 template <typename ... Args>
 void Log::info(const Args &... args) {
-    if (static_cast<int>(_config.minimal_level) <= static_cast<int>(Level::INFO)) {
-        message(Level::INFO, args...);
-    }
+    message(Level::INFO, args...);
 }
 
 template <typename ... Args>
 void Log::warning(const Args &... args) {
-    if (static_cast<int>(_config.minimal_level) <= static_cast<int>(Level::WARNING)) {
-        message(Level::WARNING, args...);
-    }
+    message(Level::WARNING, args...);
 }
 
 template <typename ... Args>
 void Log::error(const Args &... args) {
-    if (static_cast<int>(_config.minimal_level) <= static_cast<int>(Level::ERROR)) {
-        message(Level::ERROR, args...);
-    }
+    message(Level::ERROR, args...);
 }
 
 template <typename ... Args>
 void Log::critical(const Args &... args) {
-    if (static_cast<int>(_config.minimal_level) <= static_cast<int>(Level::CRITICAL)) {
-        message(Level::CRITICAL, args...);
-    }
+    message(Level::CRITICAL, args...);
 }
 
 template <typename T>

--- a/src/app/clock.cpp
+++ b/src/app/clock.cpp
@@ -1,4 +1,6 @@
 #include "app/clock.h"
+#include <ctime>
+#include <iostream>
 
 Clock::Clock() : m_start()
 {
@@ -28,4 +30,62 @@ double Clock::getTime() const
 double Clock::seconds(long long microseconds)
 {
     return static_cast<double>(microseconds) * 1e-6;
+}
+
+
+Time::Time(const std::chrono::milliseconds &dur) {
+    auto milliseconds = dur.count();
+    _ms = milliseconds%1000;
+    auto seconds = milliseconds / 1000;
+    _s = seconds%60;
+    auto minutes = seconds / 60;
+    _min = minutes%60;
+    auto hours = minutes / 60;
+    _hour = hours % 24;
+}
+
+static int absMod(int x, int d){
+    x = x < 0 ? (d - (-x)%d)%d : x % d;
+    return x;
+}
+
+void Time::addHours(int hours)
+{
+    _hour = absMod(_hour+hours, 24);
+}
+
+
+std::string Time::toStr() const {
+    char buf[16];
+    sprintf(buf, "%02d:%02d:%02d.%03d", _hour, _min, _s, _ms);
+
+    return std::string(buf);
+}
+
+std::ostream &operator<<(std::ostream &stream, const Time &t) {
+    return stream << t.toStr();
+}
+
+int SystemClock::_zone_ofs = SystemClock::getZoneOffset();
+
+int SystemClock::getZoneOffset() {
+    auto now = std::chrono::system_clock::now();
+
+    auto epoch = now.time_since_epoch();
+    Time t(std::chrono::duration_cast<std::chrono::milliseconds>(epoch));
+
+    std::time_t current_time = std::chrono::system_clock::to_time_t(now);
+    // this function use static global pointer. so it is not thread safe solution
+    std::tm* time_info = std::localtime(&current_time);
+
+    return time_info->tm_hour - t.hours();
+}
+
+Time SystemClock::getTime() {
+    auto now = std::chrono::system_clock::now();
+    auto epoch = now.time_since_epoch();
+    Time t(std::chrono::duration_cast<std::chrono::milliseconds>(epoch));
+    t.addHours(_zone_ofs);
+
+    return t;
 }

--- a/src/app/log.cpp
+++ b/src/app/log.cpp
@@ -1,0 +1,28 @@
+#include <app/log.hpp>
+
+Log::Config Log::_config;
+std::ofstream Log::log_out_fs;
+
+void Log::init() {
+    log_out_fs.open(_config.log_filename, std::ios_base::app);
+}
+
+void Log::initFromConfig(const Log::Config &init_config) {
+    _config = init_config;
+    init();
+}
+void Log::initFromConfig(const std::string &filename) {
+    json::load<Config>(filename, _config);
+    init();
+}
+
+std::ostream &operator<<(std::ostream &stream, Log::Level level) {
+    switch (level) {
+        case Log::Level::DEBUG:    return stream << "[DEBUG]";
+        case Log::Level::INFO:     return stream << "[INFO]";
+        case Log::Level::WARNING:  return stream << "[WARNING]";
+        case Log::Level::ERROR:    return stream << "[ERROR]";
+        case Log::Level::CRITICAL: return stream << "[CRITICAL]";
+        default:                   return stream;
+    }
+}

--- a/src/app/log.cpp
+++ b/src/app/log.cpp
@@ -2,6 +2,8 @@
 
 Log::Config Log::_config;
 std::ofstream Log::log_out_fs;
+std::stringstream Log::ss;
+
 
 void Log::init() {
     log_out_fs.open(_config.log_filename, std::ios_base::app);
@@ -9,10 +11,6 @@ void Log::init() {
 
 void Log::initFromConfig(const Log::Config &init_config) {
     _config = init_config;
-    init();
-}
-void Log::initFromConfig(const std::string &filename) {
-    json::load<Config>(filename, _config);
     init();
 }
 
@@ -25,4 +23,17 @@ std::ostream &operator<<(std::ostream &stream, Log::Level level) {
         case Log::Level::CRITICAL: return stream << "[CRITICAL]";
         default:                   return stream;
     }
+}
+
+bool operator<=(Log::Level l1, Log::Level l2) {
+    return static_cast<int>(l1) <= static_cast<int>(l2);
+}
+bool operator>=(Log::Level l1, Log::Level l2) {
+    return static_cast<int>(l1) >= static_cast<int>(l2);
+}
+bool operator<(Log::Level l1, Log::Level l2) {
+    return static_cast<int>(l1) < static_cast<int>(l2);
+}
+bool operator>(Log::Level l1, Log::Level l2) {
+    return static_cast<int>(l1) > static_cast<int>(l2);
 }

--- a/test/test_logger.cpp
+++ b/test/test_logger.cpp
@@ -9,7 +9,7 @@ void test_logger() {
         Log::Level::DEBUG
     };
     Log::initFromConfig(config);
-//    Log::initFromConfig("log.config");
+//    Log::initFromConfig(json::load<Log::Config>("log.config"));
 
     NonPrintable test_object {};
     // TODO: testing infrastructure

--- a/test/test_logger.cpp
+++ b/test/test_logger.cpp
@@ -6,9 +6,10 @@ void test_logger() {
     Log::Config config {
         "default.log",
         true,
-        0
+        Log::Level::DEBUG
     };
     Log::initFromConfig(config);
+//    Log::initFromConfig("log.config");
 
     NonPrintable test_object {};
     // TODO: testing infrastructure

--- a/test/test_logger.cpp
+++ b/test/test_logger.cpp
@@ -3,8 +3,14 @@
 struct NonPrintable {};
 
 void test_logger() {
+    Log::Config config {
+        "default.log",
+        true,
+        0
+    };
+    Log::initFromConfig(config);
+
     NonPrintable test_object {};
-    Log::initFromConfig("log.config");
     // TODO: testing infrastructure
     LOG_DEBUG("This is debug logging message, ", 2);
     LOG_INFO("Important information about non-printable struct: ", test_object);

--- a/test/test_logger.cpp
+++ b/test/test_logger.cpp
@@ -4,6 +4,7 @@ struct NonPrintable {};
 
 void test_logger() {
     NonPrintable test_object {};
+    Log::initFromConfig("log.config");
     // TODO: testing infrastructure
     LOG_DEBUG("This is debug logging message, ", 2);
     LOG_INFO("Important information about non-printable struct: ", test_object);


### PR DESCRIPTION
Log params can be inited from a config file or a config structure
- filename - sets the log output filename
- write_to_console - enables writing log to console
- minimal_level - sets the minimal log level that should be written

Also classes SystemClock and Time are added to write timestamps to log.