### PR TITLE
Vulkan-hpp: fix of resource creation

### DIFF
--- a/src/magma/vk/Context.cpp
+++ b/src/magma/vk/Context.cpp
@@ -47,7 +47,8 @@ Context::Context() {
         createInfo.pNext = nullptr;
     }
 
-    auto [result, _instance] = vk::createInstance(createInfo);
+    vk::Result result;
+    std::tie(result, _instance) = vk::createInstance(createInfo);
     VK_HPP_CHECK_ERR(result, "failed to create instance!");
     _c_instance = VkInstance(_instance);
 

--- a/src/magma/vk/validationLayers/DebugMessenger.cpp
+++ b/src/magma/vk/validationLayers/DebugMessenger.cpp
@@ -58,7 +58,8 @@ DebugMessenger::DebugMessenger(const vk::Instance &instance) : _instance(instanc
         return;
 
     auto createInfo = getCreateInfo();
-    auto [result, _debugMessenger] = _instance.createDebugUtilsMessengerEXT(createInfo);
+    vk::Result result;
+    std::tie(result, _debugMessenger) = _instance.createDebugUtilsMessengerEXT(createInfo);
     VK_HPP_CHECK_ERR(result, "failed to set up debug messenger!");
 }
 


### PR DESCRIPTION
Code like this:
```
auto [result, _resource] = vk::create...
```
creates local var _resource which overwrites class member