### PR TITLE
ExceptionLogger: noreturn attribute added to operator<<

### DIFF
--- a/include/magma/app/log.hpp
+++ b/include/magma/app/log.hpp
@@ -60,7 +60,7 @@ public:
         ExceptionLogger(const char *filename, int line);
 
         template <typename E>
-        void operator<<(E exception) const;
+        [[ noreturn ]] void operator<<(E exception) const;
 
     private:
         const char *_filename;


### PR DESCRIPTION
Thus compiler won't raise warnings when control reaches the end of
non-void function which ends with macro LOG_AND_THROW.