### PR TITLE
Logging and error handling refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ add_library(${LIBRARY_NAME} STATIC
 		src/magma/app/render/GBuffer.cpp
 
 		include/magma/vk/vulkan_common.h
+		src/magma/vk/vulkan_common.cpp
 		include/magma/vk/Context.h
 		src/magma/vk/Context.cpp
 		include/magma/vk/Extensions.h

--- a/include/magma/app/log.hpp
+++ b/include/magma/app/log.hpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <type_traits>
 #include <string>
+#include <string_view>
 #include <sstream>
 #include "magma/app/clock.h"
 #include "magma/app/config/JSON.h"
@@ -55,6 +56,8 @@ public:
     template <typename ... Args>
     static void critical(const Args &... args);
 
+    static std::string location(std::string_view filename, unsigned line);
+
     class ExceptionLogger {
     public:
         ExceptionLogger(const char *filename, int line);
@@ -105,12 +108,11 @@ JSON_ENUM_MAPPING(Log::Level,
 #define __FILENAME__ __FILE__
 #endif
 
-#define LOG_LOCATION_FORMAT(file, line) "[", file, ":", line, "] "
-#define LOG_DEBUG(...)    Log::debug    (LOG_LOCATION_FORMAT(__FILENAME__, __LINE__), __VA_ARGS__)
-#define LOG_INFO(...)     Log::info     (LOG_LOCATION_FORMAT(__FILENAME__, __LINE__), __VA_ARGS__)
-#define LOG_WARNING(...)  Log::warning  (LOG_LOCATION_FORMAT(__FILENAME__, __LINE__), __VA_ARGS__)
-#define LOG_ERROR(...)    Log::error    (LOG_LOCATION_FORMAT(__FILENAME__, __LINE__), __VA_ARGS__)
-#define LOG_CRITICAL(...) Log::critical (LOG_LOCATION_FORMAT(__FILENAME__, __LINE__), __VA_ARGS__)
+#define LOG_DEBUG(...)    Log::debug    (Log::location(__FILENAME__, __LINE__), __VA_ARGS__)
+#define LOG_INFO(...)     Log::info     (Log::location(__FILENAME__, __LINE__), __VA_ARGS__)
+#define LOG_WARNING(...)  Log::warning  (Log::location(__FILENAME__, __LINE__), __VA_ARGS__)
+#define LOG_ERROR(...)    Log::error    (Log::location(__FILENAME__, __LINE__), __VA_ARGS__)
+#define LOG_CRITICAL(...) Log::critical (Log::location(__FILENAME__, __LINE__), __VA_ARGS__)
 #define LOG_AND_THROW Log::ExceptionLogger(__FILENAME__, __LINE__) <<
 
 
@@ -168,6 +170,6 @@ void Log::print(std::ostream &stream, const T &object) {
 
 template <typename E>
 void Log::ExceptionLogger::operator<<(E exception) const {
-    Log::error(LOG_LOCATION_FORMAT(_filename, _line), exception.what());
+    Log::error(Log::location(_filename, _line), exception.what());
     throw exception;
 }

--- a/include/magma/app/log.hpp
+++ b/include/magma/app/log.hpp
@@ -60,14 +60,13 @@ public:
 
     class ExceptionLogger {
     public:
-        ExceptionLogger(const char *filename, int line);
+        explicit ExceptionLogger(std::string_view message);
 
         template <typename E>
         [[ noreturn ]] void operator<<(E exception) const;
 
     private:
-        const char *_filename;
-        int _line;
+        std::string _message;
 
     };
 
@@ -113,7 +112,7 @@ JSON_ENUM_MAPPING(Log::Level,
 #define LOG_WARNING(...)  Log::warning  (Log::location(__FILENAME__, __LINE__), __VA_ARGS__)
 #define LOG_ERROR(...)    Log::error    (Log::location(__FILENAME__, __LINE__), __VA_ARGS__)
 #define LOG_CRITICAL(...) Log::critical (Log::location(__FILENAME__, __LINE__), __VA_ARGS__)
-#define LOG_AND_THROW Log::ExceptionLogger(__FILENAME__, __LINE__) <<
+#define LOG_AND_THROW Log::ExceptionLogger(Log::location(__FILENAME__, __LINE__)) <<
 
 
 template <typename ... Args>
@@ -170,6 +169,6 @@ void Log::print(std::ostream &stream, const T &object) {
 
 template <typename E>
 void Log::ExceptionLogger::operator<<(E exception) const {
-    Log::error(Log::location(_filename, _line), exception.what());
+    Log::error(_message, exception.what());
     throw exception;
 }

--- a/include/magma/vk/vulkan_common.h
+++ b/include/magma/vk/vulkan_common.h
@@ -4,14 +4,11 @@
 
 #include "magma/app/log.hpp"
 
-#define VK_CHECK_ERR(result, message) {            \
-    if (result != VK_SUCCESS) {                    \
-       LOG_AND_THROW std::runtime_error(message);  \
-    }                                              \
-}
+bool isSuccess(VkResult result);
 
-#define VK_HPP_CHECK_ERR(result, message) {        \
-    if (result != vk::Result::eSuccess) {          \
-       LOG_AND_THROW std::runtime_error(message);  \
-    }                                              \
-}
+bool isSuccess(vk::Result result);
+
+#define VK_CHECK_ERR(result, message)               \
+    if (!isSuccess(result)) {                       \
+        LOG_AND_THROW std::runtime_error(message);  \
+    }

--- a/src/magma/app/App.cpp
+++ b/src/magma/app/App.cpp
@@ -150,7 +150,7 @@ vk::Sampler App::createDefaultTextureSampler(vk::Filter minFilter, vk::Filter ma
     samplerInfo.maxLod = 0.0f;
 
     auto[result, sampler] = device->getDevice().createSampler(samplerInfo);
-    VK_HPP_CHECK_ERR(result, "failed to create texture sampler!");
+    VK_CHECK_ERR(result, "failed to create texture sampler!");
 
     return sampler;
 }
@@ -205,7 +205,7 @@ void App::initVulkan() {
     initDevice();
 
     loadScene();
-    
+
     BufferManager& bufferManager = device->getBufferManager();
     vertexBuffer = bufferManager.createVertexBuffer("vertexBuffer", vertices);
     indexBuffer = bufferManager.createIndexBuffer("indexBuffer", indices);

--- a/src/magma/app/log.cpp
+++ b/src/magma/app/log.cpp
@@ -43,7 +43,6 @@ bool operator>(Log::Level l1, Log::Level l2) {
 }
 
 
-Log::ExceptionLogger::ExceptionLogger(const char *filename, int line)
-    : _filename(filename)
-    , _line(line) {
+Log::ExceptionLogger::ExceptionLogger(std::string_view message)
+    : _message(message) {
 }

--- a/src/magma/app/log.cpp
+++ b/src/magma/app/log.cpp
@@ -14,6 +14,10 @@ void Log::initFromConfig(const Log::Config &init_config) {
     init();
 }
 
+std::string Log::location(std::string_view filename, unsigned line) {
+    return "[" + std::string(filename) + ":" + std::to_string(line) + "] ";
+}
+
 std::ostream &operator<<(std::ostream &stream, Log::Level level) {
     switch (level) {
         case Log::Level::DEBUG:    return stream << "[DEBUG]";

--- a/src/magma/vk/Context.cpp
+++ b/src/magma/vk/Context.cpp
@@ -49,7 +49,7 @@ Context::Context() {
 
     vk::Result result;
     std::tie(result, _instance) = vk::createInstance(createInfo);
-    VK_HPP_CHECK_ERR(result, "failed to create instance!");
+    VK_CHECK_ERR(result, "failed to create instance!");
     _c_instance = VkInstance(_instance);
 
     #if ( VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1 )

--- a/src/magma/vk/FrameBuffer.cpp
+++ b/src/magma/vk/FrameBuffer.cpp
@@ -19,7 +19,7 @@ FrameBuffer::FrameBuffer(
 
     vk::Result result;
     std::tie(result, _frameBuffer) = _device.createFramebuffer(framebufferInfo);
-    VK_HPP_CHECK_ERR(result, "failed to create framebuffer!");
+    VK_CHECK_ERR(result, "failed to create framebuffer!");
 }
 
 FrameBuffer::FrameBuffer(FrameBuffer&& other) :

--- a/src/magma/vk/LogicalDevice.cpp
+++ b/src/magma/vk/LogicalDevice.cpp
@@ -44,7 +44,7 @@ LogicalDevice::LogicalDevice(
 
     vk::Result result;
     std::tie(result, _device) = _physDevice.device().createDevice(createInfo);
-    VK_HPP_CHECK_ERR(result, "failed to create logical device!");
+    VK_CHECK_ERR(result, "failed to create logical device!");
     LOG_INFO("Logical Device is created");
 
     acquireQueues(indices);
@@ -73,7 +73,7 @@ vk::DeviceMemory LogicalDevice::memAlloc(vk::MemoryRequirements memRequirements,
     );
 
     auto [result, deviceMemory] = _device.allocateMemory(allocInfo);
-    VK_HPP_CHECK_ERR(result, "failed to allocate memory!");
+    VK_CHECK_ERR(result, "failed to allocate memory!");
     return deviceMemory;
 }
 

--- a/src/magma/vk/ShaderModule.cpp
+++ b/src/magma/vk/ShaderModule.cpp
@@ -23,7 +23,7 @@ static std::vector<char> readFile(const std::string &filename) {
 }
 
 /// @todo add constant value
-Shader::Shader(const std::string &name, vk::Device device, const std::string &path, Stage stage) 
+Shader::Shader(const std::string &name, vk::Device device, const std::string &path, Stage stage)
         : _device(device) {
     auto shaderCode = readFile(path);
 
@@ -33,7 +33,7 @@ Shader::Shader(const std::string &name, vk::Device device, const std::string &pa
 
     vk::Result result;
     std::tie(result, _shaderModule) = _device.createShaderModule(createInfo);
-    VK_HPP_CHECK_ERR(result, "Failed to create " + name + " shader module!");
+    VK_CHECK_ERR(result, "Failed to create " + name + " shader module!");
 
 #ifndef NDEBUG
     // set the name
@@ -42,7 +42,7 @@ Shader::Shader(const std::string &name, vk::Device device, const std::string &pa
     nameInfo.objectHandle = (uint64_t)(VkShaderModule)_shaderModule;
     nameInfo.pObjectName = name.c_str();
     result = _device.setDebugUtilsObjectNameEXT(nameInfo);
-    VK_HPP_CHECK_ERR(result, "Failed to set shader name!");
+    VK_CHECK_ERR(result, "Failed to set shader name!");
 #endif
 
     _stageInfo.stage = stageToVkStage(stage);

--- a/src/magma/vk/SwapChain.cpp
+++ b/src/magma/vk/SwapChain.cpp
@@ -141,7 +141,7 @@ SwapChain::SwapChain(LogicalDevice &device, const Window &window):
 
     vk::Result result;
     std::tie(result, _swapChain) = _device.createSwapchainKHR(createInfo);
-    VK_HPP_CHECK_ERR(result, "failed to create swap chain!");
+    VK_CHECK_ERR(result, "failed to create swap chain!");
 
     _imageFormat = surfaceFormat.format;
     _extent = resolution;
@@ -152,7 +152,7 @@ SwapChain::SwapChain(LogicalDevice &device, const Window &window):
 void SwapChain::acquireImages() {
     vk::Result result;
     std::tie(result, _images) = _device.getSwapchainImagesKHR(_swapChain);
-    VK_HPP_CHECK_ERR(result, "failed to acquire swap chain images");
+    VK_CHECK_ERR(result, "failed to acquire swap chain images");
 }
 
 void SwapChain::createImageViews() {

--- a/src/magma/vk/buffers/BufferManager.cpp
+++ b/src/magma/vk/buffers/BufferManager.cpp
@@ -7,7 +7,7 @@
 #include "magma/vk/buffers/Buffer.h"
 
 
-BufferManager::BufferManager(LogicalDevice &device) 
+BufferManager::BufferManager(LogicalDevice &device)
         : _device(device),
         _commandBuffer(device.c_getDevice(), device.getGraphicsQueue().cmdPool)
 {}
@@ -32,7 +32,7 @@ Buffer& BufferManager::getBuffer(const std::string &name) {
     return _buffers.at(name);
 };
 
-Buffer& BufferManager::createBuffer(const std::string &name, vk::DeviceSize size, 
+Buffer& BufferManager::createBuffer(const std::string &name, vk::DeviceSize size,
         vk::BufferUsageFlags usage, vk::MemoryPropertyFlags properties) {
     if (bufferExists(name)) {
         LOG_AND_THROW std::invalid_argument(name + " buffer exist");
@@ -43,14 +43,14 @@ Buffer& BufferManager::createBuffer(const std::string &name, vk::DeviceSize size
     bufferInfo.sharingMode = vk::SharingMode::eExclusive;
 
     auto [result, buffer] = _device.getDevice().createBuffer(bufferInfo);
-    VK_HPP_CHECK_ERR(result, "Failed to create buffer!");
+    VK_CHECK_ERR(result, "Failed to create buffer!");
 
     vk::MemoryRequirements memRequirements = _device.getDevice().getBufferMemoryRequirements(buffer);
 
     VkDeviceMemory bufferMemory  = _device.memAlloc(memRequirements, properties);
 
     result = _device.getDevice().bindBufferMemory(buffer, bufferMemory, 0);
-    VK_HPP_CHECK_ERR(result, "Failed to bind buffer!");
+    VK_CHECK_ERR(result, "Failed to bind buffer!");
 
     BufferInfo* info = new BufferInfo;
     info->device = _device.c_getDevice();
@@ -65,7 +65,7 @@ Buffer& BufferManager::createBuffer(const std::string &name, vk::DeviceSize size
         nameInfo.objectHandle = (uint64_t)(VkBuffer)buffer;
         nameInfo.pObjectName = name.c_str();
         result = _device.getDevice().setDebugUtilsObjectNameEXT(nameInfo);
-        VK_HPP_CHECK_ERR(result, "Failed to set buffer name!");
+        VK_CHECK_ERR(result, "Failed to set buffer name!");
 #endif
 
     _buffers.emplace(name, Buffer(buffer, bufferMemory, info));
@@ -84,7 +84,7 @@ Buffer& BufferManager::createUniformBuffer(const std::string &name, vk::DeviceSi
     return createStagingBuffer(name, size, vk::BufferUsageFlagBits::eUniformBuffer);
 }
 
-Buffer& BufferManager::createBufferWithData(const std::string &name, const void* data, vk::DeviceSize dataSize, 
+Buffer& BufferManager::createBufferWithData(const std::string &name, const void* data, vk::DeviceSize dataSize,
         vk::BufferUsageFlags usage, vk::MemoryPropertyFlags properties) {
     auto isDeviceBuffer = properties & vk::MemoryPropertyFlagBits::eDeviceLocal;
     if (isDeviceBuffer) {

--- a/src/magma/vk/commands/CommandBuffer.cpp
+++ b/src/magma/vk/commands/CommandBuffer.cpp
@@ -1,7 +1,7 @@
 #include "magma/vk/commands/CommandBuffer.h"
 
 CommandBuffer::CommandBuffer(vk::Device device, vk::CommandPool commandPool)
-        : _device(device), 
+        : _device(device),
         _commandPool(commandPool) {
     vk::CommandBufferAllocateInfo allocInfo;
     allocInfo.commandPool = commandPool;
@@ -9,7 +9,7 @@ CommandBuffer::CommandBuffer(vk::Device device, vk::CommandPool commandPool)
     allocInfo.commandBufferCount = 1;
 
     vk::Result result = _device.allocateCommandBuffers(&allocInfo, &_commandBuffer);
-    VK_HPP_CHECK_ERR(result, "Failed to allocate command buffers!");
+    VK_CHECK_ERR(result, "Failed to allocate command buffers!");
 }
 
 CommandBuffer::~CommandBuffer() {
@@ -20,13 +20,13 @@ vk::CommandBuffer CommandBuffer::begin(vk::CommandBufferUsageFlags flags) {
     vk::CommandBufferBeginInfo beginInfo;
     beginInfo.flags = flags;
     vk::Result result = _commandBuffer.begin(beginInfo);
-    VK_HPP_CHECK_ERR(result, "Failed to begin recording command buffer!");
+    VK_CHECK_ERR(result, "Failed to begin recording command buffer!");
     return _commandBuffer;
 }
 
 void CommandBuffer::end() {
     vk::Result result = _commandBuffer.end();
-    VK_HPP_CHECK_ERR(result, "Failed to record command buffer!");
+    VK_CHECK_ERR(result, "Failed to record command buffer!");
 }
 
 void CommandBuffer::submit_sync(vk::Queue queue) {
@@ -35,9 +35,9 @@ void CommandBuffer::submit_sync(vk::Queue queue) {
     submitInfo.pCommandBuffers = &_commandBuffer;
 
     vk::Result result = queue.submit(submitInfo, vk::Fence());
-    VK_HPP_CHECK_ERR(result, "Failed to submit command buffer!");
+    VK_CHECK_ERR(result, "Failed to submit command buffer!");
     result = queue.waitIdle();
-    VK_HPP_CHECK_ERR(result, "Failed to wait idle command buffer!");
+    VK_CHECK_ERR(result, "Failed to wait idle command buffer!");
 }
 
 void CommandBuffer::endAndSubmit_sync(vk::Queue queue) {

--- a/src/magma/vk/commands/CommandBufferArr.cpp
+++ b/src/magma/vk/commands/CommandBufferArr.cpp
@@ -1,6 +1,6 @@
 #include "magma/vk/commands/CommandBufferArr.h"
 
-CommandBufferArr::CommandBufferArr(vk::Device device, vk::CommandPool commandPool, uint32_t count) 
+CommandBufferArr::CommandBufferArr(vk::Device device, vk::CommandPool commandPool, uint32_t count)
         : _device(device),
         _commandPool(commandPool) {
     vk::CommandBufferAllocateInfo allocInfo;
@@ -10,7 +10,7 @@ CommandBufferArr::CommandBufferArr(vk::Device device, vk::CommandPool commandPoo
 
     vk::Result result;
     std::tie(result, _commandBuffers) = _device.allocateCommandBuffers(allocInfo);
-    VK_HPP_CHECK_ERR(result, "Failed to allocate command buffers!");
+    VK_CHECK_ERR(result, "Failed to allocate command buffers!");
 }
 
 CommandBufferArr::~CommandBufferArr() {
@@ -20,13 +20,13 @@ CommandBufferArr::~CommandBufferArr() {
 vk::CommandBuffer CommandBufferArr::begin(uint32_t i) {
     vk::CommandBufferBeginInfo beginInfo;
     vk::Result result = _commandBuffers[i].begin(beginInfo);
-    VK_HPP_CHECK_ERR(result, "Failed to begin recording command buffer!");
+    VK_CHECK_ERR(result, "Failed to begin recording command buffer!");
     return _commandBuffers.at(i);
 }
 
 void CommandBufferArr::end(uint32_t i) {
     vk::Result result = _commandBuffers[i].end();
-    VK_HPP_CHECK_ERR(result, "Failed to record command buffer!");
+    VK_CHECK_ERR(result, "Failed to record command buffer!");
 }
 
 void CommandBufferArr::submit_sync(uint32_t i, vk::Queue queue) {
@@ -35,9 +35,9 @@ void CommandBufferArr::submit_sync(uint32_t i, vk::Queue queue) {
     submitInfo.pCommandBuffers = &_commandBuffers[i];
 
     vk::Result result = queue.submit(submitInfo, vk::Fence());
-    VK_HPP_CHECK_ERR(result, "Failed to submit command buffer!");
+    VK_CHECK_ERR(result, "Failed to submit command buffer!");
     result = queue.waitIdle();
-    VK_HPP_CHECK_ERR(result, "Failed to wait idle command buffer!");
+    VK_CHECK_ERR(result, "Failed to wait idle command buffer!");
 }
 
 void CommandBufferArr::endAndSubmit_sync(uint32_t i, vk::Queue queue) {

--- a/src/magma/vk/commands/CommandPool.cpp
+++ b/src/magma/vk/commands/CommandPool.cpp
@@ -8,7 +8,7 @@ vk::CommandPool CommandPool::createPool(vk::Device device, uint32_t queueFamilyI
         queueFamilyIndex);
 
     auto [result, commandPool] = device.createCommandPool(poolInfo);
-    VK_HPP_CHECK_ERR(result, "failed to create command pool!");
+    VK_CHECK_ERR(result, "failed to create command pool!");
 
     return commandPool;
 }

--- a/src/magma/vk/commands/SingleTimeCommandBuffer.cpp
+++ b/src/magma/vk/commands/SingleTimeCommandBuffer.cpp
@@ -1,7 +1,7 @@
 #include "magma/vk/commands/SingleTimeCommandBuffer.h"
 
-SingleTimeCommandBuffer::SingleTimeCommandBuffer(vk::Device device, vk::CommandPool commandPool) 
-        : _device(device), 
+SingleTimeCommandBuffer::SingleTimeCommandBuffer(vk::Device device, vk::CommandPool commandPool)
+        : _device(device),
         _commandPool(commandPool) {
     vk::CommandBufferAllocateInfo allocInfo;
     allocInfo.commandPool = commandPool;
@@ -9,12 +9,12 @@ SingleTimeCommandBuffer::SingleTimeCommandBuffer(vk::Device device, vk::CommandP
     allocInfo.commandBufferCount = 1;
 
     vk::Result result = _device.allocateCommandBuffers(&allocInfo, &_commandBuffer);
-    VK_HPP_CHECK_ERR(result, "Failed to allocate command buffers!");
+    VK_CHECK_ERR(result, "Failed to allocate command buffers!");
 
     vk::CommandBufferBeginInfo beginInfo;
     beginInfo.flags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit;
     result = _commandBuffer.begin(beginInfo);
-    VK_HPP_CHECK_ERR(result, "Failed to begin recording command buffer!");
+    VK_CHECK_ERR(result, "Failed to begin recording command buffer!");
 }
 
 SingleTimeCommandBuffer::~SingleTimeCommandBuffer() {
@@ -23,14 +23,14 @@ SingleTimeCommandBuffer::~SingleTimeCommandBuffer() {
 
 void SingleTimeCommandBuffer::endAndSubmit_sync(vk::Queue queue) {
     vk::Result result = _commandBuffer.end();
-    VK_HPP_CHECK_ERR(result, "Failed to record command buffer!");
+    VK_CHECK_ERR(result, "Failed to record command buffer!");
 
     vk::SubmitInfo submitInfo;
     submitInfo.commandBufferCount = 1;
     submitInfo.pCommandBuffers = &_commandBuffer;
 
     result = queue.submit(submitInfo, vk::Fence());
-    VK_HPP_CHECK_ERR(result, "Failed to submit command buffer!");
+    VK_CHECK_ERR(result, "Failed to submit command buffer!");
     result = queue.waitIdle();
-    VK_HPP_CHECK_ERR(result, "Failed to wait idle command buffer!");
+    VK_CHECK_ERR(result, "Failed to wait idle command buffer!");
 }

--- a/src/magma/vk/physicalDevice/PhysicalDevice.cpp
+++ b/src/magma/vk/physicalDevice/PhysicalDevice.cpp
@@ -71,7 +71,7 @@ uint32_t PhysicalDevice::findMemoryTypeInd(uint32_t typeFilter, vk::MemoryProper
 
 bool PhysicalDevice::checkExtensionSupport(const std::vector<const char*> &extensions) const {
     auto [result, availableExtensions] = _physicalDevice.enumerateDeviceExtensionProperties();
-    VK_HPP_CHECK_ERR(result, "failed to enumerate device extension properties");
+    VK_CHECK_ERR(result, "failed to enumerate device extension properties");
 
     std::set<std::string> requiredExtensions(extensions.begin(), extensions.end());
     for (const auto& extension : availableExtensions) {

--- a/src/magma/vk/textures/CustomImageView.cpp
+++ b/src/magma/vk/textures/CustomImageView.cpp
@@ -4,7 +4,7 @@
 
 #include "magma/vk/vulkan_common.h"
 
-CustomImageView::CustomImageView(Texture &texture, vk::ImageAspectFlags aspectMask) 
+CustomImageView::CustomImageView(Texture &texture, vk::ImageAspectFlags aspectMask)
         : _device(texture.getInfo()->device) {
     vk::ImageCreateInfo info = texture.getInfo()->imageInfo;
 
@@ -20,7 +20,7 @@ CustomImageView::CustomImageView(Texture &texture, vk::ImageAspectFlags aspectMa
 
     vk::Result result;
     std::tie(result, _imageView) = _device.createImageView(viewInfo);
-    VK_HPP_CHECK_ERR(result, "Failed to create image view!");
+    VK_CHECK_ERR(result, "Failed to create image view!");
 }
 
 CustomImageView::CustomImageView(vk::Device device, vk::Image image, vk::Format format, vk::ImageAspectFlags aspectMask)
@@ -38,7 +38,7 @@ CustomImageView::CustomImageView(vk::Device device, vk::Image image, vk::Format 
 
     vk::Result result;
     std::tie(result, _imageView) = _device.createImageView(viewInfo);
-    VK_HPP_CHECK_ERR(result, "Failed to create image view!");
+    VK_CHECK_ERR(result, "Failed to create image view!");
 }
 
 CustomImageView::~CustomImageView() {

--- a/src/magma/vk/textures/TextureManager.cpp
+++ b/src/magma/vk/textures/TextureManager.cpp
@@ -8,7 +8,7 @@
 #include "magma/vk/LogicalDevice.h"
 #include "magma/vk/vulkan_common.h"
 
-TextureManager::TextureManager(LogicalDevice &device) 
+TextureManager::TextureManager(LogicalDevice &device)
         : _device(device),
         _commandBuffer(device.c_getDevice(), device.getGraphicsQueue().cmdPool)
 {}
@@ -74,13 +74,13 @@ Texture& TextureManager::createTexture2D(const std::string &name, vk::Format for
     imageInfo.initialLayout = vk::ImageLayout::eUndefined;
 
     auto [result, textureImage] = _device.getDevice().createImage(imageInfo);
-    VK_HPP_CHECK_ERR(result, "Failed to create image!");
+    VK_CHECK_ERR(result, "Failed to create image!");
 
     vk::MemoryRequirements memRequirements = _device.getDevice().getImageMemoryRequirements(textureImage);
     vk::DeviceMemory textureMemory = _device.memAlloc(memRequirements, vk::MemoryPropertyFlagBits::eDeviceLocal);
 
     result = _device.getDevice().bindImageMemory(textureImage, textureMemory, 0);
-    VK_HPP_CHECK_ERR(result, "Failed to bind image memory!");
+    VK_CHECK_ERR(result, "Failed to bind image memory!");
 
     vk::ImageViewCreateInfo viewInfo;
     viewInfo.image = textureImage;
@@ -94,7 +94,7 @@ Texture& TextureManager::createTexture2D(const std::string &name, vk::Format for
 
     vk::ImageView textureView;
     std::tie(result, textureView) = _device.getDevice().createImageView(viewInfo);
-    VK_HPP_CHECK_ERR(result, "Failed to create image view!");
+    VK_CHECK_ERR(result, "Failed to create image view!");
 
     TextureInfo* textureInfo = new TextureInfo;
     textureInfo->device = _device.c_getDevice();
@@ -110,7 +110,7 @@ Texture& TextureManager::createTexture2D(const std::string &name, vk::Format for
     nameInfo.objectHandle = (uint64_t)(VkImage)textureImage;
     nameInfo.pObjectName = name.c_str();
     result = _device.getDevice().setDebugUtilsObjectNameEXT(nameInfo);
-    VK_HPP_CHECK_ERR(result, "Failed to set image name!");
+    VK_CHECK_ERR(result, "Failed to set image name!");
 #endif
 
     _textures.emplace(name, Texture(textureImage, textureMemory, ImageView(textureView), textureInfo));

--- a/src/magma/vk/validationLayers/DebugMessenger.cpp
+++ b/src/magma/vk/validationLayers/DebugMessenger.cpp
@@ -66,7 +66,7 @@ DebugMessenger::DebugMessenger(const vk::Instance &instance) : _instance(instanc
     auto createInfo = getCreateInfo();
     vk::Result result;
     std::tie(result, _debugMessenger) = _instance.createDebugUtilsMessengerEXT(createInfo);
-    VK_HPP_CHECK_ERR(result, "failed to set up debug messenger!");
+    VK_CHECK_ERR(result, "failed to set up debug messenger!");
 }
 
 DebugMessenger::~DebugMessenger() {

--- a/src/magma/vk/vulkan_common.cpp
+++ b/src/magma/vk/vulkan_common.cpp
@@ -1,0 +1,9 @@
+#include "magma/vk/vulkan_common.h"
+
+bool isSuccess(VkResult result) {
+    return result == VK_SUCCESS;
+}
+
+bool isSuccess(vk::Result result) {
+    return result == vk::Result::eSuccess;
+}


### PR DESCRIPTION
`VK_HPP_CHECK_ERR` macro usages are replaced with `VK_CHECK_ERR` since it is compiler's work to check return types
Minor changes in `Log` class